### PR TITLE
Renames theme from courtyard-blog to mitlib-courtyard-blog

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
-# Travis CI (MIT License) configuration file for the Courtyard-Blog WordPress theme.
+# Travis CI (MIT License) configuration file for the Mitlib-Courtyard-Blog WordPress theme.
 # This has been adapted from Underscores.
 # @link https://travis-ci.org/
 
-# For use with the Courtyard-Blog WordPress theme, based on Underscores
-# @link https://github.com/MITLibraries/courtyard-blog
+# For use with the Mitlib-Courtyard-Blog WordPress theme, based on Underscores
+# @link https://github.com/MITLibraries/mitlib-courtyard-blog
 
 # Declare what Travis environment should be used. Specifically, we need the
 # 'precise' environment rather than 'trusty' to get PHP 5.3.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-[![Build Status](https://travis-ci.org/MITLibraries/courtyard-blog.svg)](https://travis-ci.org/MITLibraries/courtyard-blog)
-[![Code Climate](https://codeclimate.com/github/MITLibraries/courtyard-blog/badges/gpa.svg)](https://codeclimate.com/github/MITLibraries/courtyard-blog)
-[![Stories in Ready](https://badge.waffle.io/MITLibraries/courtyard-blog.svg?label=ready&title=Ready)](http://waffle.io/MITLibraries/courtyard-blog)
+[![Build Status](https://travis-ci.org/MITLibraries/mitlib-courtyard-blog.svg)](https://travis-ci.org/MITLibraries/mitlib-courtyard-blog)
+[![Code Climate](https://codeclimate.com/github/MITLibraries/mitlib-courtyard-blog/badges/gpa.svg)](https://codeclimate.com/github/MITLibraries/mitlib-courtyard-blog)
+[![Stories in Ready](https://badge.waffle.io/MITLibraries/mitlib-courtyard-blog.svg?label=ready&title=Ready)](http://waffle.io/MITLibraries/mitlib-courtyard-blog)
 
-Courtyard-Blog
+Mitlib-Courtyard-Blog
 ======
 
-Courtyard-Blog is a child WordPress theme for use on internally-facing blogs at the MIT Libraries. It has been created by [Matt Bernhardt](https://github.com/matt-bernhardt) to extend the [Courtyard](https://github.com/MITLibraries/courtyard) base theme.
+Mitlib-Courtyard-Blog is a child WordPress theme for use on internally-facing blogs at the MIT Libraries. It has been created by [Matt Bernhardt](https://github.com/matt-bernhardt) to extend the [Mitlib-Courtyard](https://github.com/MITLibraries/mitlib-courtyard) base theme.

--- a/css/style.css
+++ b/css/style.css
@@ -1,17 +1,17 @@
 /*
- Theme Name:     Courtyard - Blog
- Theme URI:      https://github.com/MITLibraries/courtyard-blog/
+ Theme Name:     MITlib Courtyard - Blog
+ Theme URI:      https://github.com/MITLibraries/mitlib-courtyard-blog
  Description:    This is a child theme of the Courtyard template meant for blog-like websites.
  Author:         Matt Bernhardt
  Author URI:     http://github.com/matt-bernhardt/
- Template:       courtyard
- Version:        1.2.0-@@branch-@@commit
+ Template:       mitlib-courtyard
+ Version:        1.3.0-@@branch-@@commit
  License:        GNU General Public License
  License URI:    license.txt
 
 */
 
-@import '../courtyard/style.css';
+@import '../mitlib-courtyard/style.css';
 
 h1,
 .h1 {

--- a/functions.php
+++ b/functions.php
@@ -1,10 +1,10 @@
 <?php
 /**
- * Courtyard-blog functions and definitions.
+ * Mitlib-Courtyard-blog functions and definitions.
  *
  * @link https://developer.wordpress.org/themes/basics/theme-functions/
  *
- * @package Courtyard-blog
+ * @package Mitlib-Courtyard-blog
  */
 
 /**

--- a/functions.php
+++ b/functions.php
@@ -36,7 +36,7 @@ function courtyard_entry_title() {
 	$category_single = $category_single[0]->name;
 
 	// Translators: used between list items, there is a space after the comma.
-	$tag_single = str_replace( 'sticky','',strip_tags( get_the_tag_list( '', '', '' ) ) );
+	$tag_single = str_replace( 'sticky', '', strip_tags( get_the_tag_list( '', '', '' ) ) );
 
 	if ( $tag_single ) {
 		$courtyard_post_title = __( '%1$s: %2$s', 'courtyard-blog' );

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "courtyard-blog",
+  "name": "mitlib-courtyard-blog",
   "version": "1.2.0",
-  "description": "This is a child theme of the Courtyard template meant for blog-like websites.",
-  "bugs": "https://github.com/MITLibraries/courtyard-blog/issues",
+  "description": "This is a child theme of the Mitlib Courtyard template meant for blog-like websites.",
+  "bugs": "https://github.com/MITLibraries/mitlib-courtyard-blog/issues",
   "license": "GPL-3.0",
   "repository" : {
     "type": "git",
-    "url": "git+https://github.com/MITLibraries/courtyard-blog.git"
+    "url": "git+https://github.com/MITLibraries/mitlib-courtyard-blog.git"
   },
   "devDependencies": {
     "glob": "~7.1.2",

--- a/single-post.php
+++ b/single-post.php
@@ -4,7 +4,7 @@
  *
  * @link https://developer.wordpress.org/themes/basics/template-hierarchy/#single-post
  *
- * @package Courtyard
+ * @package mitlib-courtyard-blog
  */
 
 get_header(); ?>

--- a/style.css
+++ b/style.css
@@ -1,11 +1,11 @@
 /*
- Theme Name:     Courtyard - Blog
- Theme URI:      https://github.com/MITLibraries/courtyard-blog/
+ Theme Name:     MITlib Courtyard - Blog
+ Theme URI:      https://github.com/MITLibraries/mitlib-courtyard-blog
  Description:    This is a child theme of the Courtyard template meant for blog-like websites.
  Author:         Matt Bernhardt
  Author URI:     http://github.com/matt-bernhardt/
- Template:       courtyard
- Version:        1.2.0-@@branch-@@commit
+ Template:       mitlib-courtyard
+ Version:        1.3.0-@@branch-@@commit
  License:        GNU General Public License
  License URI:    license.txt
 

--- a/template-parts/content-single.php
+++ b/template-parts/content-single.php
@@ -4,7 +4,7 @@
  *
  * @link https://codex.wordpress.org/Template_Hierarchy
  *
- * @package Courtyard-blog
+ * @package mitlib-courtyard-blog
  */
 
 ?>

--- a/template-parts/content.php
+++ b/template-parts/content.php
@@ -4,7 +4,7 @@
  *
  * @link https://codex.wordpress.org/Template_Hierarchy
  *
- * @package Courtyard-blog
+ * @package mitlib-courtyard-blog
  */
 
 ?>


### PR DESCRIPTION
## Status
_Use labels (`review needed`, `in progress`, or `paused`) to declare status_

#### What does this PR do?
This renames the theme from `courtyard-blog` to `mitlib-courtyard-blog` to help avoid a name collision with the publicly-available Courtyard theme.

#### How can a reviewer manually see the effects of these changes?
By the time this review requests lands, this PR will be visible on both dev and test servers.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/NTI-188

#### Requires new or updated plugins, themes, or libraries?
SOMEWHAT - the Council site will need to be converted from the old theme to the new theme, and the old theme will need to be removed from the servers.

#### Requires change to deploy process?
NO
